### PR TITLE
Adds extensions.peewee for the peewee ORM (version 3). 

### DIFF
--- a/timeflake/extensions/peewee/__init__.py
+++ b/timeflake/extensions/peewee/__init__.py
@@ -1,0 +1,49 @@
+import uuid
+
+import timeflake
+from peewee import Field
+
+class TimeflakeBase62Field(Field):
+
+    field_type = 'CHAR'
+    def db_value(self, value):
+        if value is None:
+            return value
+
+        if not isinstance(value, timeflake.Timeflake):
+            raise ValueError(f"Timeflake expected, got: {value}")
+
+        return value.base62
+
+    def python_value(self, value):
+        if value is None:
+            return value
+
+        if isinstance(value, timeflake.Timeflake):
+            return value
+
+        return timeflake.parse(from_base62=value)
+
+
+class TimeflakeUUIDField(Field):
+    field_type = 'UUID'
+    def db_value(self, value):
+        if value is None:
+            return value
+
+        if isinstance(value, timeflake.Timeflake):
+            value = value.uuid
+
+        if not isinstance(value, uuid.UUID):
+            raise ValueError(f"UUID expected, got: {value}")
+
+        return value.hex
+
+    def python_value(self, value):
+        if value is None:
+            return value
+
+        if isinstance(value, uuid.UUID):
+            return timeflake.parse(from_hex=value.hex)
+
+        return timeflake.parse(from_hex=uuid.UUID(value).hex)


### PR DESCRIPTION
See for example: https://gist.github.com/bibby/3c7a162fb83a833850af8ff668d5441b

Includes 2 models;  one using the 22-char Base62 repr as the primary key ; and the other using UUID hex (an [existing pattern](http://docs.peewee-orm.com/en/latest/peewee/api.html#UUIDField) ).