### PR TITLE
Proposal: subclass `Timeflake` from UUID

### DIFF
--- a/timeflake/__init__.py
+++ b/timeflake/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 __all__ = ["Timeflake", "random", "from_values"]
 
 import os

--- a/timeflake/flake.py
+++ b/timeflake/flake.py
@@ -11,32 +11,19 @@ MAX_RANDOM = 1208925819614629174706175
 MAX_TIMEFLAKE = 340282366920938463463374607431768211455
 
 
-class Timeflake:
+class Timeflake(uuid.UUID):
     def __init__(self, from_bytes: bytes):
         if from_bytes is None:
             raise ValueError("from_bytes is a required parameter")
-        self._bytes = from_bytes
+        super(self.__class__, self).__init__(bytes=from_bytes)
         # Validate flake
         as_int = self.int
         if as_int < 0 or MAX_TIMEFLAKE < as_int:
             raise ValueError("Invalid flake provided")
 
     @property
-    def bytes(self) -> bytes:
-        return self._bytes
-
-    @property
     def uuid(self) -> uuid.UUID:
         return uuid.UUID(bytes=self.bytes)
-
-    @property
-    def int(self) -> int:
-        return int.from_bytes(self.bytes, "big", signed=False)
-
-    @property
-    @lru_cache(1)
-    def hex(self) -> str:
-        return itoa(self.int, HEX, padding=32)
 
     @property
     @lru_cache(1)


### PR DESCRIPTION
This closes #8  as `UUID` objects are JSON serializable in DRF.

PR proposes subclassing of `UUID` and therefore, pushes Version.