### PR TITLE
Fix KeyError in TimeflakeBinary error handling

### DIFF
--- a/timeflake/extensions/django/__init__.py
+++ b/timeflake/extensions/django/__init__.py
@@ -61,7 +61,7 @@ class TimeflakeBinary(models.Field):
             return _parse(value)
         except (AttributeError, ValueError):
             raise exceptions.ValidationError(
-                self.error_messages["invalid"], code="invalid", params={"value": value},
+                self.error_messages["invalid_choice"], code="invalid", params={"value": value},
             )
 
     def get_db_prep_value(self, value, connection, prepared=False):


### PR DESCRIPTION
The `invalid` has never apparently been supported error message in Field. The Django documentation is bit misleading as it tells that "invalid" is one of the choices, but it is not defined in the base Field class.

https://github.com/django/django/blob/517d3bb4dd17e9c51690c98d747b86a0ed8b2fbf/django/db/models/fields/__init__.py#L129